### PR TITLE
Add tags page and sample tags

### DIFF
--- a/source/_posts/example-post.md
+++ b/source/_posts/example-post.md
@@ -1,0 +1,7 @@
+---
+title: Example Post
+tags:
+  - sample
+---
+
+This is a sample article for demonstration purposes.

--- a/source/_posts/hello-world.md
+++ b/source/_posts/hello-world.md
@@ -1,13 +1,16 @@
 ---
 title: Hello World
+tags:
+  - intro
 ---
+
 Welcome to [Hexo](https://hexo.io/)! This is your very first post. Check [documentation](https://hexo.io/docs/) for more info. If you get any problems when using Hexo, you can find the answer in [troubleshooting](https://hexo.io/docs/troubleshooting.html) or you can ask me on [GitHub](https://github.com/hexojs/hexo/issues).
 
 ## Quick Start
 
 ### Create a new post
 
-``` bash
+```bash
 $ hexo new "My New Post"
 ```
 
@@ -15,7 +18,7 @@ More info: [Writing](https://hexo.io/docs/writing.html)
 
 ### Run server
 
-``` bash
+```bash
 $ hexo server
 ```
 
@@ -23,7 +26,7 @@ More info: [Server](https://hexo.io/docs/server.html)
 
 ### Generate static files
 
-``` bash
+```bash
 $ hexo generate
 ```
 
@@ -31,7 +34,7 @@ More info: [Generating](https://hexo.io/docs/generating.html)
 
 ### Deploy to remote sites
 
-``` bash
+```bash
 $ hexo deploy
 ```
 

--- a/source/tags/index.md
+++ b/source/tags/index.md
@@ -1,0 +1,4 @@
+---
+title: Tags
+type: tags
+---


### PR DESCRIPTION
## Summary
- add tags to existing posts
- create dedicated tags index page for navigation

## Testing
- `npm install`
- `npm run build`
- `npx http-server public -p 8080` & `curl -I http://localhost:8080/`
- `curl -I http://localhost:8080/archives/`
- `curl -I http://localhost:8080/2025/08/13/example-post/`
- `curl -I http://localhost:8080/2025/08/13/hello-world/`
- `curl -I http://localhost:8080/tags/`
- `curl -I http://localhost:8080/tags/sample/`
- `curl -I http://localhost:8080/tags/intro/`


------
https://chatgpt.com/codex/tasks/task_e_689c9c2000a083298f4b9ce5e999e065